### PR TITLE
Improve to MongoDB query time, performance, and set read preference

### DIFF
--- a/app/api/article/controller.py
+++ b/app/api/article/controller.py
@@ -46,6 +46,7 @@ def get_article(user, article_id):
     if article is None:
         return jsonify(msg='Articles does not exist'), 404
 
+    app.logger.info('User {} Get article {}'.format(user, article))
     return jsonify(JsonUtil.serialize(article)), 200
 
 
@@ -104,7 +105,7 @@ def create_article(user):
     # Save it to elasticsearch
     ElasticSearchUtil.save_to_es(new_article)
 
-    app.logger.info('User {} Create article {}'.format(user, new_article))
+    app.logger.info('User {} Create article {} in List ID: {}'.format(user, new_article, list_id))
     return jsonify(JsonUtil.serialize(new_article)), 200
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -37,9 +37,9 @@ class DeployConfig(BaseConfig):
     DEBUG = True
 
     MONGODB_SETTINGS = {
-        'DB': 'raspberry',
-        'HOST': 'mongo',
-        'PORT': 27017
+        'HOST': 'mongodb://mongo,mongo1,mongo2/raspberry',
+        'PORT': 27017,
+        'replicaset': 'mongo-replica'
     }
 
     ELASTICSEARCH_SETTINGS = {
@@ -47,6 +47,7 @@ class DeployConfig(BaseConfig):
         'ELASTICSEARCH_AUTH': ('elastic', 'changeme'),
         'ELASTICSEARCH_PORT': 9200
     }
+
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,6 @@
+from pymongo.read_preferences import ReadPreference
+
+
 class BaseConfig(object):
     DEBUG = False
 
@@ -39,7 +42,8 @@ class DeployConfig(BaseConfig):
     MONGODB_SETTINGS = {
         'HOST': 'mongodb://mongo,mongo1,mongo2/raspberry',
         'PORT': 27017,
-        'replicaset': 'mongo-replica'
+        'replicaset': 'mongo-replica',
+        'READ_PREFERENCE': ReadPreference.SECONDARY
     }
 
     ELASTICSEARCH_SETTINGS = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
             - mongo
             - mongo1
             - mongo2
-        external_links:
             - elastic:elasticsearch
     mongo:
         image: mongo:3.4.1
@@ -52,6 +51,43 @@ services:
             - mongo-replica2:/data/db
         ports:
             - 30001:27017
+    elastic:
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.1.2
+        container_name: elastic
+        ports:
+            - 9200:9200
+        volumes:
+            - elastic-data:/usr/share/elasticsearch/data
+        networks:
+            - esnet
+        environment:
+            - http.host=0.0.0.0
+            - transport.host=127.0.0.1
+            - cluster.name=collabrative_list_docker_cluster
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: 1g
+        cap_add:
+            - IPC_LOCK
+    kibana:
+        image: docker.elastic.co/kibana/kibana:5.1.2
+        container_name: kibana
+        ports:
+            - 5601:5601
+        networks:
+            - esnet
+        environment:
+            - ELASTICSEARCH_PASSWORD=changeme
+            - ELASTICSEARCH_USERNAME=elastic
+        links:
+            - elastic:elasticsearch
 
 networks:
   esnet:
@@ -63,4 +99,6 @@ volumes:
     mongo-replica1:
         driver: local
     mongo-replica2:
+        driver: local
+    elastic-data:
         driver: local


### PR DESCRIPTION
## Changes
* Fix replication glitch with mongoengine
* Improve read performance
* Improve query time
* Set read preference to secondary db
* move elasticsearch and kibana into docker-compose.yml file